### PR TITLE
Keep http client alive if the server prematurely closes the connection after sending all the headers and inspecting mode is turned on

### DIFF
--- a/thor/http/client.py
+++ b/thor/http/client.py
@@ -43,7 +43,7 @@ from thor.tls import TlsClient
 
 from common import HttpMessageHandler, \
     CLOSE, COUNTED, CHUNKED, NOBODY, \
-    WAITING, ERROR, \
+    WAITING, HEADERS_DONE, ERROR, \
     idempotent_methods, no_body_status, hop_by_hop_hdrs, \
     header_names
 from error import UrlError, ConnectError, \
@@ -300,6 +300,9 @@ class HttpClientExchange(HttpMessageHandler, EventEmitter):
             self.input_error(ConnectError(
                 "Server dropped connection before the response was complete."
             ))
+            
+            if self._input_state == HEADERS_DONE and self.inspecting:
+                self.input_end([])
 
     def _retry(self):
         "Retry the request."


### PR DESCRIPTION
Hey Mark,

I haven't given up on that duplicate CL issue for redbot :) Anyway, this change enables the thor http client to continue processing when multiple CL headers are present, and the final CL has a value that is higher than the actual body length. In this case, when the server closes the connection - the client currently raises an input_error in _conn_closed since it expected more bytes. However, if inspecting mode is turned on - the client should try make the best of the situation and continue processing as if the complete body was received (so that redbot can report the error). As far as I can see, there is no (nice) way to handle this in redbot alone, so I'm hacking into thor also.
