### PR TITLE
Dont truncate received http body to match CL header value if in inspecting mode

### DIFF
--- a/thor/http/common.py
+++ b/thor/http/common.py
@@ -271,7 +271,10 @@ class HttpMessageHandler:
         "Handle input where the body is delimited by the Content-Length."
         if self._input_body_left <= len(instr): # got it all (and more?)
             self.input_transfer_length += self._input_body_left
-            self.input_body(instr[:self._input_body_left])
+            if not self.inspecting:
+                self.input_body(instr[:self._input_body_left])
+            else:
+                self.input_body(instr)
             self.input_end([])
             self._input_state = WAITING
             if instr[self._input_body_left:]:


### PR DESCRIPTION
This enables thor to pass the whole body to redbot in case the value of the CL header is smaller than len(body). Currently, redbot thinks that the CL header value matches the length of the body (since only a prefix of the body is passed to it), which is not true.
