### PR TITLE
Add close arg to response_done; suppress duplicate request_done after early response

### DIFF
--- a/test/test_http_server.py
+++ b/test/test_http_server.py
@@ -329,6 +329,70 @@ Content-Length: 5
             server.idle_timeout, conn.close_conn
         )
 
+    def test_response_done_close_closes_tcp(self):
+        tcp_conn = FakeTcpConnection()
+        server = FakeServer()
+        conn = HttpServerConnection(tcp_conn, server)
+        exchange = HttpServerExchange(conn, b"POST", b"/", [], b"1.1")
+        conn.ex_queue = [exchange]
+
+        exchange.response_start(b"413", b"Content Too Large", [])
+        exchange.response_body(b"too big")
+        exchange.response_done([], close=True)
+
+        self.assertFalse(tcp_conn.tcp_connected)
+        self.assertIsNone(conn.tcp_conn)
+
+    def test_response_done_default_keeps_connection(self):
+        tcp_conn = FakeTcpConnection()
+        server = FakeServer()
+        conn = HttpServerConnection(tcp_conn, server)
+        exchange = HttpServerExchange(conn, b"GET", b"/", [], b"1.1")
+        exchange.req_complete = True
+        conn.ex_queue = [exchange]
+
+        exchange.response_start(b"200", b"OK", [(b"Content-Length", b"0")])
+        exchange.response_done([])
+
+        self.assertTrue(tcp_conn.tcp_connected)
+
+    def test_early_response_drops_remaining_body(self):
+        tcp_conn = FakeTcpConnection()
+        server = FakeServer()
+        conn = HttpServerConnection(tcp_conn, server)
+
+        request_done_count = [0]
+
+        def handle_exchange(exchange):
+            @on(exchange, "request_body")
+            def on_body(chunk):
+                if not exchange.res_complete:
+                    exchange.response_start(
+                        b"413", b"Content Too Large", [(b"Content-Length", b"0")]
+                    )
+                    exchange.response_done([], close=True)
+
+            @on(exchange, "request_done")
+            def on_done(trailers):
+                request_done_count[0] += 1
+
+        server.emit = lambda event, *args: (
+            handle_exchange(args[0]) if event == "exchange" else None
+        )
+
+        conn.handle_input(
+            b"POST / HTTP/1.1\r\n"
+            b"Host: example.com\r\n"
+            b"Content-Length: 10\r\n"
+            b"\r\n"
+            b"0123456789"
+        )
+
+        self.assertEqual(request_done_count[0], 0)
+        self.assertFalse(tcp_conn.tcp_connected)
+        output = b"".join(tcp_conn.output)
+        self.assertIn(b"HTTP/1.1 413 Content Too Large", output)
+
     def test_reentrancy(self):
         def server_side(server):
             def check(exchange):

--- a/thor/http/server.py
+++ b/thor/http/server.py
@@ -204,13 +204,17 @@ class HttpServerConnection(HttpMessageHandler, EventEmitter):
 
     def input_body(self, chunk: bytes) -> None:
         "Process a request body chunk from the wire."
-        self.ex_queue[-1].emit("request_body", chunk)
+        ex = self.ex_queue[-1]
+        if ex.res_complete:
+            return
+        ex.emit("request_body", chunk)
 
     def input_end(self, trailers: RawHeaderListType) -> None:
         "Indicate that the request body is complete."
         ex = self.ex_queue[-1]
         ex.req_complete = True
-        ex.emit("request_done", trailers)
+        if not ex.res_complete:
+            ex.emit("request_done", trailers)
         if ex.res_complete and ex in self.ex_queue:
             self.ex_queue.remove(ex)
 
@@ -320,14 +324,18 @@ class HttpServerExchange(EventEmitter):
         "Send part of the response body. May be called zero to many times."
         self.http_conn.output_body(chunk)
 
-    def response_done(self, trailers: RawHeaderListType) -> None:
+    def response_done(
+        self, trailers: RawHeaderListType, close: bool = False
+    ) -> None:
         """
         Signal the end of the response, whether or not there was a body. MUST
-        be called exactly once for each response.
+        be called exactly once for each response. If close is True, the
+        underlying TCP connection is closed after the response is flushed,
+        regardless of response framing.
         """
-        close = self.http_conn.output_end(trailers)
+        should_close = self.http_conn.output_end(trailers)
         self.http_conn.exchange_done(self)
-        if close and self.http_conn.tcp_conn:
+        if (should_close or close) and self.http_conn.tcp_conn:
             self.http_conn.close_conn()
 
 


### PR DESCRIPTION
response_done now accepts close=True to close the TCP connection after flushing, regardless of framing. Lets server handlers cleanly send an early response (413, 401, etc.) before the request body finishes and shut the connection without reaching into private state.

Also stops re-emitting request_done after an early response: once res_complete is set, input_body drops further chunks and input_end skips the duplicate emit. Handlers no longer need defensive "already responded" guards to avoid OutputStateError.