### PR TITLE
Fixed: emit() skipped listeners when one removed itself mid-iteration

### DIFF
--- a/test/test_events.py
+++ b/test/test_events.py
@@ -135,6 +135,24 @@ class TestEventEmitter(unittest.TestCase):
         self.assertEqual(self.t.foo_count, 0)
         self.assertEqual(self.t.rem1_count, 2)
 
+    def test_multiple_once_listeners_all_fire(self):
+        """
+        Multiple once() listeners for the same event must all fire
+        on a single emit, even though each removes itself before
+        calling its target.
+        """
+        count = [0]
+
+        def inc():
+            count[0] += 1
+
+        ee = EventEmitter()
+        ee.once("ping", inc)
+        ee.once("ping", inc)
+        ee.once("ping", inc)
+        ee.emit("ping")
+        self.assertEqual(count[0], 3)
+
     def test_remove_listener_recursion(self):
         """
         Removing a later listener specifically for

--- a/test/test_http_client.py
+++ b/test/test_http_client.py
@@ -958,6 +958,13 @@ class TestHttpClient(framework.ClientServerTestCase):
         def client_side(client, test_host, test_port):
             exchange = client.exchange()
 
+            self.check_exchange(
+                exchange,
+                {
+                    "error": thor.http.error.ConnectError,
+                },
+            )
+
             @on(exchange)
             def response_done(trailers):
                 self.fail("Should have failed")
@@ -966,13 +973,6 @@ class TestHttpClient(framework.ClientServerTestCase):
             def error(err_msg):
                 self.assertEqual(err_msg.__class__, thor.http.error.ConnectError)
                 self.loop.stop()
-
-            self.check_exchange(
-                exchange,
-                {
-                    "error": thor.http.error.ConnectError,
-                },
-            )
 
             req_uri = b"http://%s:%i/req_retry_fail" % (
                 test_host,

--- a/thor/events.py
+++ b/thor/events.py
@@ -101,8 +101,9 @@ class EventEmitter:
         """
         events = self.__events.get(event, [])
         if events:
-            for ev in events:
-                ev(*args)
+            for ev in list(events):
+                if ev in events:
+                    ev(*args)
         else:
             sink_event = getattr(self.__sink, event, None)
             if sink_event:


### PR DESCRIPTION
EventEmitter.emit() iterated the live listener list. When a listener removed an entry (notably the wrapper installed by once()), the list shifted and the next listener was skipped. Multiple once() listeners on the same event silently dropped all but the first.

Iterate a snapshot, but check membership before invoking so that the existing documented behavior — a listener can suppress a *later* listener by removing it — is preserved.

The test_req_retry_fail test was passing only because of this same bug: client._close_conns (a once() stop listener on the loop) was absorbing the first loop.stop() and skipping the test's own stop assertion until check_exchange's error handler had set test_happened=True. Reorder the test's listener registration so check_exchange's error handler runs first.