### PR TITLE
Fixed: re-entrant close in _handle_close after drained-data callback

### DIFF
--- a/thor/tcp.py
+++ b/thor/tcp.py
@@ -279,6 +279,8 @@ class TcpConnection(EventSource):
             return
         if drain:
             eof = self._drain_readable()
+            if not self.tcp_connected:
+                return
             if not eof:
                 self.event_add("fd_readable")
                 if self.close_timeout > 0 and not self._close_timeout_ev:
@@ -291,6 +293,8 @@ class TcpConnection(EventSource):
 
     def _close_after_drain_timeout(self) -> None:
         self._drain_readable()
+        if not self.tcp_connected:
+            return
         if self._close():
             self.emit("close")
 


### PR DESCRIPTION
_handle_close() calls _drain_readable(), which synchronously emits "data" events. A listener can call close()/abort() on the connection, leaving tcp_connected=False before _handle_close returns. The post-drain path would then either rearm fd_readable on a closed fd or run _close() a second time and emit "close" twice — which in turn drives duplicate conn_closed dispatches at the HTTP layer.

Re-check tcp_connected after _drain_readable() in both _handle_close() and _close_after_drain_timeout(), and bail if the connection has already been torn down by a re-entrant handler.