### PR TITLE
Fixed: orphaned close-timeout when peer FIN races with local close

### DIFF
--- a/thor/tcp.py
+++ b/thor/tcp.py
@@ -270,7 +270,7 @@ class TcpConnection(EventSource):
         self.event_del("fd_writable")
         self.event_add("fd_readable")
         self._input_paused = False
-        if self.close_timeout > 0:
+        if self.close_timeout > 0 and not self._close_timeout_ev:
             self._close_timeout_ev = self.loop.schedule(self.close_timeout, self._close)
 
     def _handle_close(self, drain: bool = True) -> None:


### PR DESCRIPTION
_shutdown_output() unconditionally overwrote self._close_timeout_ev. If _handle_close() had already armed the drain-timeout (because the peer FIN arrived first), local close() -> _shutdown_output() would clobber the reference: the earlier scheduled callback still fires, later re-entering _close() against a connection whose fd may have been recycled.

Mirror the guard already present in _handle_close(): only arm the shutdown timeout when one is not already scheduled.