### PR TITLE
Claude/naughty hugle 810a82

### DIFF
--- a/test/test_loop.py
+++ b/test/test_loop.py
@@ -135,19 +135,6 @@ class TestLoop(unittest.TestCase):
 
         self.assertEqual(order, ["first-start", "first-end", "second"])
 
-    def test_time(self):
-        run_time = 2
-
-        def check_time():
-            self.assertTrue(
-                abs(systime.time() - self.loop.time()) <= self.loop.precision
-            )
-            self.loop.stop()
-
-        self.loop.schedule(run_time, check_time)
-        self.loop.run()
-
-
 class TestEventSource(unittest.TestCase):
     def setUp(self):
         self.loop = thor.loop.make()

--- a/thor/__init__.py
+++ b/thor/__init__.py
@@ -7,8 +7,6 @@ Thor is a Python library for evented IO, with a focus on enabling
 high-performance HTTP intermediaries.
 """
 
-from __future__ import absolute_import
-
 __author__ = "Mark Nottingham <mnot@mnot.net>"
 __copyright__ = """\
 Copyright (c) 2005- Mark Nottingham

--- a/thor/http/__init__.py
+++ b/thor/http/__init__.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import absolute_import
-
 from thor.http.client import HttpClient, HttpClientExchange
 from thor.http.common import (
     get_header,

--- a/thor/http/server.py
+++ b/thor/http/server.py
@@ -13,7 +13,7 @@ will block the entire server.
 
 import os
 import sys
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Set, Tuple
 
 from thor.events import EventEmitter, on
 from thor.http.common import (
@@ -48,12 +48,12 @@ class HttpServer(EventEmitter):
         self.loop = self.tcp_server.loop
         self.tcp_server.on("connect", self.handle_conn)
         self.loop.schedule(0, self.emit, "start")
-        self.connections: List["HttpServerConnection"] = []
+        self.connections: Set["HttpServerConnection"] = set()
         self.shutting_down = False
 
     def handle_conn(self, tcp_conn: TcpConnection) -> None:
         http_conn = HttpServerConnection(tcp_conn, self)
-        self.connections.append(http_conn)
+        self.connections.add(http_conn)
         tcp_conn.on("data", http_conn.handle_input)
         tcp_conn.on("disconnect", http_conn.conn_closed)
         tcp_conn.on("pause", http_conn.res_body_pause)
@@ -137,8 +137,7 @@ class HttpServerConnection(HttpMessageHandler, EventEmitter):
 
     def conn_closed(self) -> None:
         "The server connection has closed."
-        if self in self.server.connections:
-            self.server.connections.remove(self)
+        self.server.connections.discard(self)
         self.ex_queue = []
         self.tcp_conn = None
 

--- a/thor/http/server.py
+++ b/thor/http/server.py
@@ -92,7 +92,6 @@ class HttpServerConnection(HttpMessageHandler, EventEmitter):
         self.server = server
         self.ex_queue: List[HttpServerExchange] = []  # queue of exchanges
         self.output_paused = False
-        self.output_paused = False
         self._idler: Optional[ScheduledEvent] = self.server.loop.schedule(
             self.server.idle_timeout, self.close_conn
         )

--- a/thor/http/server.py
+++ b/thor/http/server.py
@@ -323,9 +323,7 @@ class HttpServerExchange(EventEmitter):
         "Send part of the response body. May be called zero to many times."
         self.http_conn.output_body(chunk)
 
-    def response_done(
-        self, trailers: RawHeaderListType, close: bool = False
-    ) -> None:
+    def response_done(self, trailers: RawHeaderListType, close: bool = False) -> None:
         """
         Signal the end of the response, whether or not there was a body. MUST
         be called exactly once for each response. If close is True, the

--- a/thor/loop.py
+++ b/thor/loop.py
@@ -27,7 +27,7 @@ from typing import (
 from thor.events import EventEmitter
 from thor.types import EventListener, ScheduledEventTuple
 
-__all__ = ["run", "stop", "schedule", "time"]
+__all__ = ["run", "stop", "schedule"]
 
 
 class EventSource(EventEmitter):
@@ -215,10 +215,6 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
         "An event has occured on an fd."
         if fd in self._fd_targets:
             self._fd_targets[fd].emit(event)
-
-    def time(self) -> float:
-        "Return the current time (deprecated)."
-        return systime.time()
 
     def schedule(
         self, delta: float, callback: EventListener, *args: Any
@@ -560,4 +556,3 @@ _loop = make()  # by default, just one big loop.
 run = _loop.run
 stop = _loop.stop
 schedule = _loop.schedule
-time = _loop.time

--- a/thor/loop.py
+++ b/thor/loop.py
@@ -97,7 +97,7 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
         self.precision = precision or 0.1  # of running scheduled queue (secs)
         self.running = False  # whether or not the loop is running (read-only)
         self.debug = False
-        self.__profiler: cProfile.Profile
+        self.__profiler: Optional[cProfile.Profile] = None
         self.__sched_events: List[ScheduledEventTuple] = []
         self._fd_targets: Dict[int, EventSource] = {}
         self.__last_event_check: float = 0.0
@@ -118,7 +118,7 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
         if self.debug:
             self.__profiler = cProfile.Profile()
         while self.running:
-            if self.debug:
+            if self.debug and self.__profiler is not None:
                 fd_start = systime.monotonic()
                 self.__profiler.enable()
                 self._run_fd_events()
@@ -154,7 +154,7 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
             when, what = self.__sched_events[0]
             if self.running and when <= self.__last_event_check:
                 self.__sched_events.pop(0)
-                if self.debug:
+                if self.debug and self.__profiler is not None:
                     ev_start = systime.monotonic()
                     self.__profiler.enable()
                     what()

--- a/thor/loop.py
+++ b/thor/loop.py
@@ -7,6 +7,7 @@ This is a generic library for building asynchronous event loops, using
 Python's built-in poll / epoll / kqueue support.
 """
 
+import bisect
 import contextvars
 import cProfile
 import errno
@@ -238,8 +239,9 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
 
         cb = partial(ctx_callback, *args)
         new_event = (systime.monotonic() + delta, cb)
-        events = self.__sched_events
-        self._insort(events, new_event)
+        bisect.insort(
+            self.__sched_events, new_event, key=lambda ev: ev[0]  # type: ignore[type-var,misc]
+        )
         return ScheduledEvent(self, new_event)
 
     def schedule_del(self, event: ScheduledEventTuple) -> None:
@@ -247,22 +249,6 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
             self.__sched_events.remove(event)
         except ValueError:  # already gone
             pass
-
-    @staticmethod
-    def _insort(
-        li: List[Any], thing: Any, lo: int = 0, hi: Optional[int] = None
-    ) -> None:
-        if lo < 0:
-            raise ValueError("lo must be non-negative")
-        if hi is None:
-            hi = len(li)
-        while lo < hi:
-            mid = (lo + hi) // 2
-            if thing[0] < li[mid][0]:
-                hi = mid
-            else:
-                lo = mid + 1
-        li.insert(lo, thing)
 
     def _eventmask(self, events: Iterable[str]) -> int:
         "Calculate the mask for a list of events."

--- a/thor/tcp.py
+++ b/thor/tcp.py
@@ -94,20 +94,18 @@ class TcpConnection(EventSource):
     read_bufsize = 1024 * 16  # bytes
     close_timeout = 5  # seconds
 
-    block_errs = set([errno.EAGAIN, errno.EWOULDBLOCK, errno.ETIMEDOUT])
-    close_errs = set(
-        [
-            errno.EBADF,
-            errno.ECONNRESET,
-            errno.ESHUTDOWN,
-            errno.ECONNABORTED,
-            errno.ECONNREFUSED,
-            errno.EHOSTUNREACH,
-            errno.ENETUNREACH,
-            errno.ENOTCONN,
-            errno.EPIPE,
-        ]
-    )
+    block_errs = {errno.EAGAIN, errno.EWOULDBLOCK, errno.ETIMEDOUT}
+    close_errs = {
+        errno.EBADF,
+        errno.ECONNRESET,
+        errno.ESHUTDOWN,
+        errno.ECONNABORTED,
+        errno.ECONNREFUSED,
+        errno.EHOSTUNREACH,
+        errno.ENETUNREACH,
+        errno.ENOTCONN,
+        errno.EPIPE,
+    }
 
     def __init__(
         self, sock: socket.socket, address: Address, loop: Optional[LoopBase] = None


### PR DESCRIPTION
## Summary
- Remove duplicated/dead code spotted in a cruft pass: doubled `output_paused` assignment, Python 2 `__future__` imports, deprecated `LoopBase.time()`.
- Replace hand-rolled `_insort` with `bisect.insort` (stdlib supports `key=` since 3.10; project requires 3.10+).
- Fix latent `AttributeError` on `LoopBase.__profiler` when debug-mode code runs without `run()` having been called.
- Modernize `set([...])` → `{...}` in `TcpConnection`; switch `HttpServer.connections` from `List` to `Set` for O(1) membership/removal.

No behavior changes intended. All commits keep mypy clean, pylint at 10/10, and the full test suite passing.
