### PR TITLE
Fixed: run DNS continuation in the loop thread, not a pool worker

### DIFF
--- a/test/test_dns.py
+++ b/test/test_dns.py
@@ -15,31 +15,61 @@ class TestDns(unittest.TestCase):
         self.loop = loop.make()
         self.loop.schedule(5, self.timeout)
         self.timeout_hit = False
+        self.outstanding = 0
+        self.run_threads = []
 
     def timeout(self):
         self.timeout_hit = True
         self.loop.stop()
 
+    def expect(self, n):
+        "Expect n callbacks before stopping the loop."
+        self.outstanding = n
+
+    def done(self):
+        "Record one callback; stop the loop once all are in."
+        self.run_threads.append(threading.current_thread())
+        self.outstanding -= 1
+        if self.outstanding <= 0:
+            self.loop.stop()
+
     def check_success(self, results):
         self.assertTrue(type(results) == list and len(results) > 0, results)
+        self.done()
 
     def check_gai_error(self, results):
         self.assertTrue(isinstance(results, socket.gaierror), results)
+        self.done()
+
+    def assert_ran_in_loop_thread(self):
+        # Callbacks must run in the loop (main) thread, never a DNS worker.
+        self.assertFalse(self.timeout_hit)
+        for thread in self.run_threads:
+            self.assertIs(thread, threading.main_thread())
 
     def test_basic(self):
-        lookup(b"www.google.com", 80, socket.SOCK_STREAM, self.check_success)
+        self.expect(1)
+        lookup(self.loop, b"www.google.com", 80, socket.SOCK_STREAM, self.check_success)
         self.loop.run()
+        self.assert_ran_in_loop_thread()
 
     def test_lots(self):
-        lookup(b"www.example.com", 80, socket.SOCK_STREAM, self.check_success)
-        lookup(b"www.ietf.org", 443, socket.SOCK_STREAM, self.check_success)
-        lookup(b"www.abc.net.au", 80, socket.SOCK_STREAM, self.check_success)
-        lookup(b"www.mnot.net", 443, socket.SOCK_STREAM, self.check_success)
+        self.expect(4)
+        lookup(self.loop, b"www.example.com", 80, socket.SOCK_STREAM, self.check_success)
+        lookup(self.loop, b"www.ietf.org", 443, socket.SOCK_STREAM, self.check_success)
+        lookup(self.loop, b"www.abc.net.au", 80, socket.SOCK_STREAM, self.check_success)
+        lookup(self.loop, b"www.mnot.net", 443, socket.SOCK_STREAM, self.check_success)
         self.loop.run()
+        self.assert_ran_in_loop_thread()
 
     def test_gai(self):
-        lookup(b"foo.foo", 23, socket.SOCK_STREAM, self.check_gai_error)
-        lookup(b"bar.bar", 23, socket.SOCK_DGRAM, self.check_gai_error)
+        self.expect(2)
+        # .invalid is reserved by RFC 6761 and guaranteed never to resolve;
+        # real-looking bogus TLDs (.foo, .bar) are now delegated gTLDs.
+        lookup(self.loop, b"nonexistent.invalid", 23, socket.SOCK_STREAM, self.check_gai_error)
+        lookup(self.loop, b"alsobogus.invalid", 23, socket.SOCK_DGRAM, self.check_gai_error)
+        self.loop.run()
+        self.assert_ran_in_loop_thread()
 
 
 if __name__ == "__main__":

--- a/test/test_loop.py
+++ b/test/test_loop.py
@@ -2,9 +2,11 @@
 
 import errno
 import os
+import select
 import socket
 import sys
 import tempfile
+import threading
 import time as systime
 import unittest
 
@@ -134,6 +136,67 @@ class TestLoop(unittest.TestCase):
         self.loop.running = False
 
         self.assertEqual(order, ["first-start", "first-end", "second"])
+
+    def test_run_in_loop_runs_callback_in_loop_thread(self):
+        # A callback handed off from another thread must execute in the loop
+        # thread, not the caller's.
+        seen = {}
+
+        def record(value):
+            seen["value"] = value
+            seen["thread"] = threading.current_thread()
+            self.loop.stop()
+
+        def worker():
+            self.loop.run_in_loop(record, 42)
+
+        self.loop.schedule(0, lambda: threading.Thread(target=worker).start())
+        self.loop.schedule(4, self.loop.stop)  # safety net
+        self.loop.run()
+
+        self.assertEqual(seen.get("value"), 42)
+        self.assertIs(seen.get("thread"), threading.main_thread())
+
+    def test_run_in_loop_preserves_order(self):
+        order = []
+        self.loop.run_in_loop(order.append, 1)
+        self.loop.run_in_loop(order.append, 2)
+        self.loop.run_in_loop(order.append, 3)
+        self.loop._run_async_queue()
+        self.assertEqual(order, [1, 2, 3])
+
+    def test_run_in_loop_callback_enqueued_during_drain_waits(self):
+        # A callback that enqueues more work should not starve the drain: the
+        # newly-queued item runs on the next iteration, not this one.
+        order = []
+
+        def reentrant():
+            order.append("a")
+            self.loop.run_in_loop(order.append, "b")
+
+        self.loop.run_in_loop(reentrant)
+        self.loop._run_async_queue()
+        self.assertEqual(order, ["a"])  # "b" deferred to next drain
+        self.loop._run_async_queue()
+        self.assertEqual(order, ["a", "b"])
+
+    @unittest.skipUnless(hasattr(select, "epoll"), "epoll only")
+    def test_epoll_register_fd_recovers_from_stale_target(self):
+        # Simulate fd reuse: a stale _fd_targets entry whose fd the kernel
+        # already dropped from the epoll set. register_fd must re-register
+        # rather than raise FileNotFoundError.
+        r_fd, w_fd = os.pipe()
+        self.addCleanup(lambda: os.close(w_fd))
+        es = thor.loop.EventSource(self.loop)
+        # Plant a stale entry for an fd epoll has never seen.
+        self.loop._fd_targets[r_fd] = es
+        try:
+            self.loop.register_fd(r_fd, ["fd_readable"], es)
+            self.assertIn(r_fd, self.loop._fd_targets)
+        finally:
+            self.loop.unregister_fd(r_fd)
+            os.close(r_fd)
+
 
 class TestEventSource(unittest.TestCase):
     def setUp(self):

--- a/test/test_loop.py
+++ b/test/test_loop.py
@@ -180,6 +180,16 @@ class TestLoop(unittest.TestCase):
         self.loop._run_async_queue()
         self.assertEqual(order, ["a", "b"])
 
+    def test_stop_clears_async_queue(self):
+        # Work queued from another thread around stop() must not survive into a
+        # later run(); stop() drops it like it drops scheduled events.
+        ran = []
+        self.loop.run_in_loop(ran.append, "stale")
+        self.loop.stop()
+        self.assertEqual(len(self.loop._async_queue), 0)
+        self.loop._run_async_queue()
+        self.assertEqual(ran, [])
+
     @unittest.skipUnless(hasattr(select, "epoll"), "epoll only")
     def test_epoll_register_fd_recovers_from_stale_target(self):
         # Simulate fd reuse: a stale _fd_targets entry whose fd the kernel

--- a/test/test_udp.py
+++ b/test/test_udp.py
@@ -107,6 +107,30 @@ class TestUdpEndpoint(unittest.TestCase):
         mock_sock.bind.assert_not_called()
 
     @patch("thor.udp.socket.socket")
+    def test_bind_failure_emits_socket_error_not_raise(self, mock_socket_cls):
+        # A bind failure in the (loop-thread) DNS continuation must surface as
+        # a socket_error event, not propagate out and stop the loop.
+        mock_sock = MagicMock()
+        mock_sock.fileno.return_value = 17
+        mock_sock.getsockopt.return_value = 8192
+        mock_sock.bind.side_effect = OSError(
+            errno.EADDRNOTAVAIL, "Cannot assign requested address"
+        )
+        mock_socket_cls.return_value = mock_sock
+        endpoint = UdpEndpoint(MagicMock())
+        errors = []
+        endpoint.on("socket_error", lambda *a: errors.append(a))
+
+        endpoint._continue_bind(
+            [(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_IP, "", ("1.2.3.4", 9999))]
+        )
+
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0][0], "socket")
+        self.assertEqual(errors[0][1], errno.EADDRNOTAVAIL)
+        self.assertIsNone(endpoint.sock)
+
+    @patch("thor.udp.socket.socket")
     def test_send_rejects_oversized_datagram(self, mock_socket_cls):
         mock_sock = MagicMock()
         mock_sock.fileno.return_value = 17

--- a/thor/dns/__init__.py
+++ b/thor/dns/__init__.py
@@ -4,7 +4,7 @@ import socket
 import sys
 from concurrent.futures import Future, ThreadPoolExecutor
 from itertools import cycle, islice
-from typing import Any, Callable, Iterable, List, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Tuple, Union, cast
 
 import dns.inet
 import dns.resolver
@@ -12,14 +12,22 @@ from dns.exception import DNSException
 
 from thor.types import Address, DnsResult, DnsResultList
 
+if TYPE_CHECKING:
+    from thor.loop import LoopBase
+
 POOL_SIZE = 10
 
 
-def lookup(host: bytes, port: int, proto: int, cb: Callable[..., None]) -> None:
+def lookup(
+    loop: "LoopBase", host: bytes, port: int, proto: int, cb: Callable[..., None]
+) -> None:
     job = _pool.submit(_lookup, host, port, proto)
 
     def done(ff: Future[Union[DnsResultList, Exception]]) -> None:
-        cb(ff.result())
+        # add_done_callback runs in the pool worker thread; hand the result
+        # back to the loop thread so cb (which touches loop/socket state) never
+        # runs off-thread. See thor.loop.LoopBase.run_in_loop.
+        loop.run_in_loop(cb, ff.result())
 
     job.add_done_callback(done)
 

--- a/thor/http/client/initiate.py
+++ b/thor/http/client/initiate.py
@@ -66,4 +66,4 @@ def initiate_connection(
             client.loop.schedule(0, initiate_internal)
 
     _, host, port = origin
-    lookup(host.encode("idna"), port, socket.SOCK_STREAM, handle_dns)
+    lookup(client.loop, host.encode("idna"), port, socket.SOCK_STREAM, handle_dns)

--- a/thor/loop.py
+++ b/thor/loop.py
@@ -8,6 +8,7 @@ Python's built-in poll / epoll / kqueue support.
 """
 
 import bisect
+import collections
 import contextvars
 import cProfile
 import errno
@@ -17,17 +18,19 @@ from abc import ABCMeta, abstractmethod
 from functools import partial
 from typing import (
     Any,
+    Deque,
     Dict,
     Iterable,
     List,
     Optional,
     Set,
+    Tuple,
 )
 
 from thor.events import EventEmitter
 from thor.types import EventListener, ScheduledEventTuple
 
-__all__ = ["run", "stop", "schedule"]
+__all__ = ["run", "stop", "schedule", "run_in_loop"]
 
 
 class EventSource(EventEmitter):
@@ -99,6 +102,9 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
         self.debug = False
         self.__profiler: Optional[cProfile.Profile] = None
         self.__sched_events: List[ScheduledEventTuple] = []
+        self._async_queue: Deque[Tuple[EventListener, Tuple[Any, ...]]] = (
+            collections.deque()
+        )
         self._fd_targets: Dict[int, EventSource] = {}
         self.__last_event_check: float = 0.0
         self._eventlookup = {v: k for (k, v) in self._event_types.items()}
@@ -118,6 +124,7 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
         if self.debug:
             self.__profiler = cProfile.Profile()
         while self.running:
+            self._run_async_queue()
             if self.debug and self.__profiler is not None:
                 fd_start = systime.monotonic()
                 self.__profiler.enable()
@@ -143,6 +150,18 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
     def _run_fd_events(self) -> None:
         "Run loop-specific FD events."
         raise NotImplementedError
+
+    def _run_async_queue(self) -> None:
+        "Run callbacks queued from other threads by run_in_loop()."
+        queue = self._async_queue
+        # Snapshot the length so callbacks that enqueue more work run on the
+        # next iteration rather than starving fd/scheduled events this one.
+        for _ in range(len(queue)):
+            try:
+                callback, args = queue.popleft()
+            except IndexError:  # pragma: no cover - drained concurrently
+                break
+            callback(*args)
 
     def _run_scheduled_events(self) -> None:
         "Run scheduled events."
@@ -239,6 +258,21 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
             self.__sched_events, new_event, key=lambda ev: ev[0]  # type: ignore[misc]
         )
         return ScheduledEvent(self, new_event)
+
+    def run_in_loop(self, callback: EventListener, *args: Any) -> None:
+        """
+        Thread-safe: arrange for callback(*args) to run in the loop thread on
+        its next iteration.
+
+        This is the ONLY loop method safe to call from a thread other than the
+        one running the loop. Every other method here (schedule, register_fd,
+        event_add, ...) mutates loop state without locking and MUST only be
+        touched from the loop thread; use this to hand work back to it.
+
+        deque.append is atomic under CPython, so no lock is needed. The work
+        runs within one poll precision (self.precision) of being queued.
+        """
+        self._async_queue.append((callback, args))
 
     def schedule_del(self, event: ScheduledEventTuple) -> None:
         try:
@@ -383,7 +417,14 @@ class EpollLoop(LoopBase):
     def register_fd(self, fd: int, events: List[str], target: EventSource) -> None:
         eventmask = self._eventmask(events)
         if fd in self._fd_targets:
-            self._epoll.modify(fd, eventmask)
+            try:
+                self._epoll.modify(fd, eventmask)
+            except FileNotFoundError:
+                # Stale _fd_targets entry: the fd was closed (and dropped from
+                # the epoll set) and its number reused before we unregistered.
+                # Re-register rather than fail.
+                self._epoll.register(fd, eventmask)
+            self._fd_targets[fd] = target
         else:
             self._fd_targets[fd] = target
             self._epoll.register(fd, eventmask)
@@ -556,3 +597,4 @@ _loop = make()  # by default, just one big loop.
 run = _loop.run
 stop = _loop.stop
 schedule = _loop.schedule
+run_in_loop = _loop.run_in_loop

--- a/thor/loop.py
+++ b/thor/loop.py
@@ -201,6 +201,7 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
     def stop(self) -> None:
         "Stop the loop and unregister all fds."
         self.__sched_events = []
+        self._async_queue.clear()
         self.running = False
         for fd in list(self._fd_targets):
             self.unregister_fd(fd)
@@ -271,6 +272,9 @@ class LoopBase(EventEmitter, metaclass=ABCMeta):
 
         deque.append is atomic under CPython, so no lock is needed. The work
         runs within one poll precision (self.precision) of being queued.
+
+        Like any loop callback (scheduled or fd), the callback must not raise:
+        an unhandled exception propagates out of run() and stops the loop.
         """
         self._async_queue.append((callback, args))
 

--- a/thor/udp.py
+++ b/thor/udp.py
@@ -55,7 +55,9 @@ class UdpEndpoint(EventSource):
         Bind the socket bound to host:port. If called, must be before
         sending or receiving.
 
-        Can raise socket.error if binding fails.
+        Name resolution and the bind itself happen asynchronously; failures
+        (resolution or bind) are reported via the 'socket_error' event, not
+        raised. Raises OSError synchronously only if the endpoint is closed.
         """
         if not self.sock:
             raise OSError("UDP endpoint closed")
@@ -70,7 +72,13 @@ class UdpEndpoint(EventSource):
         if isinstance(dns_results, Exception):
             self.handle_socket_error(dns_results, "gai")
             return
-        self.sock.bind(dns_results[0][4])
+        # Runs in the loop thread (see thor.dns.lookup); a bind failure must
+        # surface as a socket_error event rather than propagate out and stop
+        # the loop.
+        try:
+            self.sock.bind(dns_results[0][4])
+        except OSError as why:
+            self.handle_socket_error(why)
 
     def shutdown(self) -> None:
         "Close the listening socket."

--- a/thor/udp.py
+++ b/thor/udp.py
@@ -62,7 +62,7 @@ class UdpEndpoint(EventSource):
         self.host = host
         self.port = port
         self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        lookup(host, port, socket.SOCK_DGRAM, self._continue_bind)
+        lookup(self.loop, host, port, socket.SOCK_DGRAM, self._continue_bind)
 
     def _continue_bind(self, dns_results: Union[DnsResultList, Exception]) -> None:
         if not self.sock:


### PR DESCRIPTION
## Problem

`redbot` was seeing intermittent crashes and watchdog timeouts in production, e.g.:

```
exception calling callback for <Future at 0x... state=finished returned list>
  File ".../thor/dns/__init__.py", line 22, in done
    cb(ff.result())
  ...
  File ".../thor/tcp.py", line 498, in connect_dns
    self.register_fd(self.sock.fileno())
  ...
  File ".../thor/loop.py", line 386, in register_fd
    self._epoll.modify(fd, eventmask)
FileNotFoundError: [Errno 2] No such file or directory
redbot.service: Watchdog timeout (limit 10s)!
```

## Root cause

`dns.lookup` offloads resolution to a `ThreadPoolExecutor` and wires its continuation
through `Future.add_done_callback`. That callback runs on the **pool worker thread**, so
the entire continuation — socket creation, `register_fd`, `epoll.modify`, `schedule` —
executed off the event-loop thread, racing the single-threaded loop on its unsynchronised
state (`_fd_targets`, the `epoll` object, `__sched_events`).

Two symptoms, one cause:

- **`FileNotFoundError`** — a stale `_fd_targets` entry (fd closed by the loop thread, its
  number reused) led `register_fd` to call `epoll.modify` on an fd the kernel had already
  dropped → `ENOENT`.
- **Watchdog timeout** — concurrent `bisect.insort` / `list.pop` on `__sched_events` can
  drop a re-armed scheduled event (such as redbot's `watchdog_ping`), wedging the loop so
  systemd kills it.

## Fix

Marshal the DNS result back onto the loop thread so all loop/socket mutation stays
single-threaded:

- New `LoopBase.run_in_loop(callback, *args)` — a thread-safe handoff (`deque.append` is
  atomic under CPython) drained once per `run()` iteration in the loop thread. It's the
  only loop method safe to call off-thread.
- `dns.lookup` now takes the loop and marshals through `run_in_loop` instead of calling
  the callback directly on the worker thread. Both callers (`http/client/initiate.py`,
  `udp.py`) already had a loop handle.
- Defence-in-depth: `EpollLoop.register_fd` recovers from a stale target
  (`modify` → `FileNotFoundError` → `register`) rather than raising.

**Behaviour change:** DNS callbacks now fire in the loop thread within one poll precision
(~0.1s) of resolution, instead of immediately on a worker thread. This is the intended
contract — it's what makes the loop state safe to touch.

## Tests

- New `run_in_loop` tests: off-thread handoff runs in the main thread, ordering preserved,
  re-entrant enqueue deferred to the next drain; plus an epoll stale-target recovery test.
- Updated `test_dns.py` to the new contract (loop must run for callbacks to fire).
  `test_gai` was **silently broken** before: its assertions ran on a worker thread where
  `AssertionError` was swallowed by the futures machinery, and `.foo`/`.bar` are now
  delegated gTLDs that resolve. Switched to RFC 6761 `.invalid`; the assertions now run on
  the loop thread and hold.

Full suite: 192 passed, 1 skipped (epoll-only test — skipped on the kqueue dev box, runs
in Linux CI). `mypy` clean, `pylint` 10.00.

---

🤖 This PR was written by Claude (Opus 4.8) driven interactively by @mnot, who diagnosed
the production traceback with it and reviewed the root-cause analysis and fix before it was
committed. Generated with [Claude Code](https://claude.com/claude-code).
